### PR TITLE
feat: configure @app/web to be built with ESM

### DIFF
--- a/services/web/package.json
+++ b/services/web/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@app/web",
   "version": "0.0.1",
+  "type": "module",
   "private": true,
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 0",


### PR DESCRIPTION
Adds `"type": "module"` to the `package.json` of `@app/web`.

This explicitly marks the package as an ES Module package, which is the standard way to configure a package for ESM. The Astro build was already using ESM internally, and the build continues to succeed after this change.