### PR TITLE
Refactor: Pass footer menu as props

### DIFF
--- a/packages/ui/src/Footer/Footer.stories.tsx
+++ b/packages/ui/src/Footer/Footer.stories.tsx
@@ -7,4 +7,26 @@ const meta: Meta<typeof Footer> = {
 
 export default meta;
 
-export const Basic: StoryObj<typeof Footer> = {};
+export const Basic: StoryObj<typeof Footer> = {
+  args: {
+    menus: [
+      {
+        title: "Documentation",
+        children: [
+          { name: "Getting Started", href: "#" },
+          { name: "Guide", href: "#" },
+          { name: "API", href: "#" },
+          { name: "Showcase", href: "#" },
+          { name: "Pricing", href: "#" },
+        ],
+      },
+      {
+        title: "Community",
+        children: [
+          { name: "Forum", href: "#" },
+          { name: "Discord", href: "#" },
+        ],
+      },
+    ],
+  },
+};

--- a/packages/ui/src/Footer/index.tsx
+++ b/packages/ui/src/Footer/index.tsx
@@ -1,26 +1,20 @@
 import { Citrus, Github } from "lucide-preact";
 
-export default function Footer() {
-  const menus = [
-    {
-      title: "Documentation",
-      children: [
-        { name: "Getting Started", href: "#" },
-        { name: "Guide", href: "#" },
-        { name: "API", href: "#" },
-        { name: "Showcase", href: "#" },
-        { name: "Pricing", href: "#" },
-      ],
-    },
-    {
-      title: "Community",
-      children: [
-        { name: "Forum", href: "#" },
-        { name: "Discord", href: "#" },
-      ],
-    },
-  ];
+type MenuItem = {
+  name: string;
+  href: string;
+};
 
+type Menu = {
+  title: string;
+  children: MenuItem[];
+};
+
+export type FooterProps = {
+  menus: Menu[];
+};
+
+export default function Footer({ menus }: FooterProps) {
   return (
     <div class="bg-white flex flex-col md:flex-row w-full max-w-screen-lg gap-8 md:gap-16 px-8 py-8 text-sm">
       <div class="flex-1">


### PR DESCRIPTION
The Footer component was refactored to receive menu items via props instead of having them hardcoded.

- Defined TypeScript types for the menu structure (`MenuItem`, `Menu`, `FooterProps`).
- Modified the `Footer` component to accept a `menus` prop.
- Updated the Storybook story to provide the `menus` data through args.