### PR TITLE
Monthly dependency updates and set 9renpoto as reviewer/assignee

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,17 @@ updates:
     labels:
       - "Type: Maintenance"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    reviewers:
+      - "9renpoto"
   - package-ecosystem: npm
     directory: "/"
     labels:
       - "Type: Maintenance"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    reviewers:
+      - "9renpoto"
     groups:
       preact:
         patterns:
@@ -33,4 +37,6 @@ updates:
     labels:
       - "Type: Maintenance"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    reviewers:
+      - "9renpoto"

--- a/.github/workflows/bump-schedule.yml
+++ b/.github/workflows/bump-schedule.yml
@@ -2,7 +2,7 @@ name: Bump version (cron)
 
 on:
   schedule:
-    - cron: "15 3 * * TUE"
+    - cron: "15 3 1 * *"
 
 jobs:
   scheduled_bump:

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -89,5 +89,7 @@ jobs:
           title: "chore: bump v${{ steps.get_version.outputs.NEW_VERSION }}"
           labels: |
             Type: Documentation
+          reviewers: 9renpoto
+          assignees: 9renpoto
           draft: true
           milestone: "v${{ steps.get_version.outputs.NEW_VERSION }}"


### PR DESCRIPTION
Changed the dependency update cycle (Dependabot and version bumps) to monthly.
Assigned `9renpoto` as a reviewer for all these updates and as an assignee for version bump PRs.

---
*PR created automatically by Jules for task [1796483835261609468](https://jules.google.com/task/1796483835261609468) started by @9renpoto*