### PR TITLE
Add Dependabot cooldown and expand package grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       interval: "monthly"
     reviewers:
       - "9renpoto"
+    cooldown:
+      default-days: 7
   - package-ecosystem: npm
     directory: "/"
     labels:
@@ -16,11 +18,14 @@ updates:
       interval: "monthly"
     reviewers:
       - "9renpoto"
+    cooldown:
+      default-days: 7
     groups:
       preact:
         patterns:
           - "@preact*"
           - "preact"
+          - "preact-render-to-string"
       9renpoto:
         patterns:
           - "@9renpoto*"
@@ -32,6 +37,16 @@ updates:
         patterns:
           - "astro"
           - "@astrojs/*"
+          - "@codecov/astro-plugin"
+      twind:
+        patterns:
+          - "@twind/*"
+      testing:
+        patterns:
+          - "@testing-library/*"
+          - "vitest"
+          - "@vitest/*"
+          - "happy-dom"
   - package-ecosystem: devcontainers
     directory: "/"
     labels:
@@ -40,3 +55,5 @@ updates:
       interval: "monthly"
     reviewers:
       - "9renpoto"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
This change updates the Dependabot configuration to:
1. Add a 7-day cooldown period (`default-days: 7`) to all ecosystems (`github-actions`, `npm`, `devcontainers`) to improve security and reduce noise from very recent releases.
2. Implement more aggressive grouping for the `npm` ecosystem by:
   - Refining the `preact` and `astro` groups to include related plugins.
   - Adding a `twind` group for `@twind/*` packages.
   - Adding a `testing` group to bundle `vitest`, `@vitest/*`, `@testing-library/*`, and `happy-dom` updates.
   
These changes aim to streamline the dependency update process and provide a safety buffer for new releases.

---
*PR created automatically by Jules for task [11160478058644893018](https://jules.google.com/task/11160478058644893018) started by @9renpoto*