### PR TITLE
Add zizmor-action for GitHub Actions security analysis

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,23 @@
+name: zizmor
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6


### PR DESCRIPTION
I have introduced `zizmorcore/zizmor-action` to the repository by creating a new GitHub Actions workflow file `.github/workflows/zizmor.yml`.

- The workflow runs on pushes to the `main` branch and on all pull requests.
- It uses the recommended configuration with GitHub Advanced Security integration.
- Actions are pinned to commit hashes for security.
- Permissions are explicitly defined for SARIF upload and repository access.

---
*PR created automatically by Jules for task [14106539538760343373](https://jules.google.com/task/14106539538760343373) started by @9renpoto*