### PR TITLE
fix(ci): stabilize Node CI Playwright setup

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 10
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.59.1-noble
 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,6 +16,8 @@ jobs:
       contents: read
     timeout-minutes: 10
     runs-on: ubuntu-slim
+    container:
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
 
     strategy:
       matrix:
@@ -29,9 +31,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
       - run: npm ci
-
-      - name: Install Playwright
-        run: npx playwright install --with-deps
 
       - name: Build dependencies
         run: npm run build --workspace=@app/ui


### PR DESCRIPTION
Modified the Node CI workflow to use a Playwright container image, following the pattern in the referenced PR. This change stabilizes the CI environment and potentially improves performance by using a pre-configured image with all necessary browser dependencies.

---
*PR created automatically by Jules for task [4095723765399674737](https://jules.google.com/task/4095723765399674737) started by @9renpoto*